### PR TITLE
Add basic line art colorization app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # Colorize-my-lineart-drawings
-Project for maintain the possibility to colorize line art drawings
+
+Simple tools for coloring black and white line drawings. The original image is never modified; a new colorized version is created instead.
+
+## Usage
+
+### Command line
+
+```bash
+python colorize.py path/to/lineart.png
+```
+The colorized image is saved alongside the original with ``_colorized`` appended to its name.
+
+### Web app
+
+Run the Gradio application to colorize drawings directly from the browser:
+
+```bash
+python app.py
+```
+
+Upload a line drawing and download the generated colorized copy.
+
+## Installation
+
+Install dependencies from ``requirements.txt``:
+
+```bash
+pip install -r requirements.txt
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,31 @@
+import gradio as gr
+import numpy as np
+from PIL import Image
+from tempfile import NamedTemporaryFile
+import os
+
+from colorize import colorize_lineart
+
+
+def interface(image: np.ndarray) -> Image.Image:
+    """Gradio interface function that returns a colorized version of the image."""
+    with NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+        Image.fromarray(image).save(tmp.name)
+        result_path = colorize_lineart(tmp.name)
+        result = Image.open(result_path).convert("RGB")
+    os.remove(tmp.name)
+    os.remove(result_path)
+    return result
+
+
+demo = gr.Interface(
+    fn=interface,
+    inputs=gr.Image(type="numpy"),
+    outputs="image",
+    title="Line Art Colorizer",
+    description="Upload a line drawing to receive a colorized copy. The original image is never modified."
+)
+
+
+if __name__ == "__main__":
+    demo.launch()

--- a/colorize.py
+++ b/colorize.py
@@ -1,0 +1,52 @@
+import cv2
+import numpy as np
+import os
+from typing import Optional
+
+def colorize_lineart(image_path: str, output_path: Optional[str] = None) -> str:
+    """Colorize a line art drawing.
+
+    The function reads a black and white line drawing from ``image_path`` and
+    creates a new colorized image. The original file is left untouched.
+
+    Args:
+        image_path: Path to the input line art image.
+        output_path: Optional path for the result. Defaults to ``<name>_colorized.png``.
+
+    Returns:
+        The path to the colorized image.
+    """
+    gray = cv2.imread(image_path, cv2.IMREAD_GRAYSCALE)
+    if gray is None:
+        raise FileNotFoundError(f"Cannot load image {image_path}")
+
+    white_mask = cv2.threshold(gray, 240, 255, cv2.THRESH_BINARY)[1]
+    num_labels, labels = cv2.connectedComponents(white_mask)
+
+    color_img = np.ones((*gray.shape, 3), dtype=np.uint8) * 255
+    for label in range(1, num_labels):
+        mask = labels == label
+        color = np.random.randint(0, 256, size=3, dtype=np.uint8)
+        color_img[mask] = color
+
+    line_mask = cv2.threshold(gray, 240, 255, cv2.THRESH_BINARY_INV)[1]
+    color_img[line_mask == 255] = 0
+
+    if output_path is None:
+        root, _ = os.path.splitext(image_path)
+        output_path = f"{root}_colorized.png"
+
+    cv2.imwrite(output_path, color_img)
+    return output_path
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Colorize a line art image")
+    parser.add_argument("image", help="Path to the line art image")
+    parser.add_argument("-o", "--output", help="Optional path for the colorized image")
+    args = parser.parse_args()
+
+    result_path = colorize_lineart(args.image, args.output)
+    print(f"Saved colorized image to {result_path}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+opencv-python
+numpy
+Pillow
+gradio


### PR DESCRIPTION
## Summary
- add colorize_lineart utility for coloring black & white drawings without touching originals
- expose a Gradio web app for uploading and colorizing line art
- document usage and dependencies

## Testing
- `python -m py_compile colorize.py app.py`
- `pip install pillow opencv-python-headless gradio numpy` *(fails: Could not connect to proxy)*
- `python colorize.py sample_lineart.png` *(fails: No module named 'cv2')*


------
https://chatgpt.com/codex/tasks/task_e_6896a8b1b8a0832c843826826e70dad9